### PR TITLE
Add license to manifest and remove ds-lime requirement for conda-forge

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 # Include the license file
 include description.rst
+include LICENSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-cython
-scipy>=0.15
-numpy>=1.10
-scikit-learn>=0.18
-pandas>=0.17


### PR DESCRIPTION
To get the package approved for conda-forge, we need to include the license file in the manifest. Also, there appears to be an orphaned requirement, `ds-lime`. I've removed it from the setup file. Is this correct?

Cython is not a requirement either and can also be dropped?