### PR TITLE
Correction to work with Python 3

### DIFF
--- a/skater/core/global_interpretation/partial_dependence.py
+++ b/skater/core/global_interpretation/partial_dependence.py
@@ -136,7 +136,7 @@ class PartialDependence(BaseGlobalInterpretation):
         return "{}".format(columnname)
 
     def _check_features(self, feature_ids):
-        if not hasattr(feature_ids, "__iter__"):
+        if isinstance(feature_or_feature_pair, str):
             feature_ids = [feature_ids]
 
         if len(feature_ids) >= 3:

--- a/skater/core/global_interpretation/partial_dependence.py
+++ b/skater/core/global_interpretation/partial_dependence.py
@@ -136,7 +136,7 @@ class PartialDependence(BaseGlobalInterpretation):
         return "{}".format(columnname)
 
     def _check_features(self, feature_ids):
-        if isinstance(feature_or_feature_pair, str):
+        if isinstance(feature_ids, str):
             feature_ids = [feature_ids]
 
         if len(feature_ids) >= 3:


### PR DESCRIPTION
I have a TooManyFeaturesError using plot_partial_dependence with Python 3 that does not occur with Python 2.
It seems to be caused by "hasattr(feature_or_feature_pair, 'iter')" in the _check_features function (line 139 of partial_dependence.py). String are iterable with Python 3 but were not with Python 2.
Replacing this line by "not isinstance(feature_or_feature_pair, str)" should correct this.