### PR TITLE
force exception into using map instead of mapper when n_jobs==1

### DIFF
--- a/skater/core/global_interpretation/partial_dependence.py
+++ b/skater/core/global_interpretation/partial_dependence.py
@@ -387,6 +387,8 @@ class PartialDependence(BaseGlobalInterpretation):
 
         pd_list = []
         try:
+            if n_jobs == 1:
+                raise ValueError("Skipping to single processing")
             for pd_row in mapper(pd_func, arg_list):
                 if progressbar:
                     p.animate()


### PR DESCRIPTION
The PartialDependence class currently tries multiprocessing even when n_jobs==1. This code adopted from the FeatureImportance class should fix this from happening.