### PR TITLE
simplifying tests related to BRL to resolve frequent segmentation fault

### DIFF
--- a/skater/tests/test_rule_list.py
+++ b/skater/tests/test_rule_list.py
@@ -32,6 +32,10 @@ class TestRuleList(unittest.TestCase):
         self.input_data = self.input_data.dropna()
         self.y = self.input_data['Survived']
         self.input_data = self.input_data.drop(['Survived'], axis=1)
+        self.sbrl_inst.fit(self.input_data[1:50], self.y[1:50], undiscretize_feature_list=["PassengerId", "Pclass",
+                                                                                           "SibSp", "Parch",
+                                                                                           "Sex_Encoded",
+                                                                                           "Embarked_Encoded"])
 
 
     def test_discretizer(self):
@@ -40,16 +44,11 @@ class TestRuleList(unittest.TestCase):
 
 
     def test_model_build(self):
-        self.sbrl_inst.fit(self.input_data[1:50], self.y[1:50],
-                           undiscretize_feature_list=["PassengerId", "Pclass",
-                                                      "SibSp", "Parch", "Sex_Encoded",
-                                                      "Embarked_Encoded"])
-
         new_data = self.sbrl_inst.discretizer(self.input_data, column_list=["Age", "Fare"])
         result_score = self.sbrl_inst.predict_proba(new_data)
         result_labels = self.sbrl_inst.predict(new_data)
 
-        # make sure shape of the dataframe is as expected
+        # make sure shape of the data-frame is as expected
         self.assertEquals(result_score.shape, (77, 2))
         self.assertEquals(result_labels[1].shape, (77, ))
 
@@ -58,12 +57,7 @@ class TestRuleList(unittest.TestCase):
         self.assertEquals(np.array_equal(generated_labels, expected_labels), True)
 
 
-
     def test_model_save_load(self):
-        self.sbrl_inst.fit(self.input_data[1:50], self.y[1:50], undiscretize_feature_list=["PassengerId", "Pclass",
-                                                                                           "SibSp", "Parch",
-                                                                                           "Sex_Encoded",
-                                                                                           "Embarked_Encoded"])
         self.sbrl_inst.save_model("test.pkl", compress=True)
         # Explicitly assigning the model instance to 'None' to validate loading of persisted model
         # Care is advised when handing the model instance, it might make the model unstable
@@ -74,10 +68,6 @@ class TestRuleList(unittest.TestCase):
 
 
     def test_model_output(self):
-        self.sbrl_inst.fit(self.input_data[1:50], self.y[1:50], undiscretize_feature_list=["PassengerId", "Pclass",
-                                                                                           "SibSp", "Parch",
-                                                                                           "Sex_Encoded",
-                                                                                           "Embarked_Encoded"])
         result = self.sbrl_inst.access_learned_rules('23:25')
         self.assertEquals(len(result), 2)
 

--- a/skater/tests/test_rule_list.py
+++ b/skater/tests/test_rule_list.py
@@ -24,20 +24,20 @@ class TestRuleList(unittest.TestCase):
         cls.sbrl_inst = BRLC(min_rule_len=1, max_rule_len=2, iterations=10000, n_chains=3)
         cls.input_data = pd.read_csv('skater/tests/data/sample_data.csv')
         # data transformation and cleaning ...
-        cls.input_data["Sex"] = self.input_data["Sex"].astype('category')
-        cls.input_data["Sex_Encoded"] = self.input_data["Sex"].cat.codes
-        cls.input_data["Embarked"] = self.input_data["Embarked"].astype('category')
-        cls.input_data["Embarked_Encoded"] = self.input_data["Embarked"].cat.codes
-        cls.input_data = self.input_data.drop(['Ticket', 'Cabin', 'Name', 'Sex', 'Embarked'], axis=1)
+        cls.input_data["Sex"] = cls.input_data["Sex"].astype('category')
+        cls.input_data["Sex_Encoded"] = cls.input_data["Sex"].cat.codes
+        cls.input_data["Embarked"] = cls.input_data["Embarked"].astype('category')
+        cls.input_data["Embarked_Encoded"] = cls.input_data["Embarked"].cat.codes
+        cls.input_data = cls.input_data.drop(['Ticket', 'Cabin', 'Name', 'Sex', 'Embarked'], axis=1)
         # Remove NaN values
-        cls.input_data = self.input_data.dropna()
-        cls.y = self.input_data['Survived']
-        cls.input_data = self.input_data.drop(['Survived'], axis=1)
+        cls.input_data = cls.input_data.dropna()
+        cls.y = cls.input_data['Survived']
+        cls.input_data = cls.input_data.drop(['Survived'], axis=1)
         # Train a model
         cls.sbrl_inst.fit(cls.input_data[1:50], cls.y[1:50], undiscretize_feature_list=["PassengerId", "Pclass",
-                                                                                           "SibSp", "Parch",
-                                                                                           "Sex_Encoded",
-                                                                                           "Embarked_Encoded"])
+                                                                                        "SibSp", "Parch",
+                                                                                        "Sex_Encoded",
+                                                                                        "Embarked_Encoded"])
 
 
     def test_discretizer(self):

--- a/skater/tests/test_rule_list.py
+++ b/skater/tests/test_rule_list.py
@@ -19,20 +19,22 @@ if sys.version_info >= (3, 5):
 @unittest.skipIf(sys.version_info < (3, 5), "only Bayesian Rule List supported only for python 3.5/3.6")
 class TestRuleList(unittest.TestCase):
 
-    def setUp(self):
-        self.sbrl_inst = BRLC(min_rule_len=1, max_rule_len=2, iterations=10000, n_chains=3)
-        self.input_data = pd.read_csv('skater/tests/data/sample_data.csv')
+    @classmethod
+    def setUpClass(cls):
+        cls.sbrl_inst = BRLC(min_rule_len=1, max_rule_len=2, iterations=10000, n_chains=3)
+        cls.input_data = pd.read_csv('skater/tests/data/sample_data.csv')
         # data transformation and cleaning ...
-        self.input_data["Sex"] = self.input_data["Sex"].astype('category')
-        self.input_data["Sex_Encoded"] = self.input_data["Sex"].cat.codes
-        self.input_data["Embarked"] = self.input_data["Embarked"].astype('category')
-        self.input_data["Embarked_Encoded"] = self.input_data["Embarked"].cat.codes
-        self.input_data = self.input_data.drop(['Ticket', 'Cabin', 'Name', 'Sex', 'Embarked'], axis=1)
+        cls.input_data["Sex"] = self.input_data["Sex"].astype('category')
+        cls.input_data["Sex_Encoded"] = self.input_data["Sex"].cat.codes
+        cls.input_data["Embarked"] = self.input_data["Embarked"].astype('category')
+        cls.input_data["Embarked_Encoded"] = self.input_data["Embarked"].cat.codes
+        cls.input_data = self.input_data.drop(['Ticket', 'Cabin', 'Name', 'Sex', 'Embarked'], axis=1)
         # Remove NaN values
-        self.input_data = self.input_data.dropna()
-        self.y = self.input_data['Survived']
-        self.input_data = self.input_data.drop(['Survived'], axis=1)
-        self.sbrl_inst.fit(self.input_data[1:50], self.y[1:50], undiscretize_feature_list=["PassengerId", "Pclass",
+        cls.input_data = self.input_data.dropna()
+        cls.y = self.input_data['Survived']
+        cls.input_data = self.input_data.drop(['Survived'], axis=1)
+        # Train a model
+        cls.sbrl_inst.fit(cls.input_data[1:50], cls.y[1:50], undiscretize_feature_list=["PassengerId", "Pclass",
                                                                                            "SibSp", "Parch",
                                                                                            "Sex_Encoded",
                                                                                            "Embarked_Encoded"])


### PR DESCRIPTION
Since training models at times might be memory intensive, simplifying test_rule_list.py to train a model once and re-use the model instance for other tests.