### PR TITLE
DataManager fails with Pandas DataFrames

### DIFF
--- a/skater/core/global_interpretation/feature_importance.py
+++ b/skater/core/global_interpretation/feature_importance.py
@@ -325,7 +325,10 @@ def compute_feature_importance(feature_id, input_data, estimator_fn,
 
     copy_of_data_set[feature_id] = samples.reshape(-1)
 
-    new_predictions = estimator_fn(copy_of_data_set.values)
+    if copy_of_data_set.data_type == np.ndarray:
+        new_predictions = estimator_fn(copy_of_data_set.values)
+    else:
+        new_predictions = estimator_fn(copy_of_data_set.X)
 
     importance = compute_importance(new_predictions,
                                     original_predictions,

--- a/skater/data/datamanager.py
+++ b/skater/data/datamanager.py
@@ -103,7 +103,7 @@ class DataManager(object):
 
         self.X = self._check_X(X)
         self.y = self._check_y(y, self.X)
-        self.data_type = type(X)
+        self.data_type = type(self.X)
         self.metastore = None
 
         self.logger.debug("after transform X.shape: {}".format(self.X.shape))

--- a/skater/tests/test_data.py
+++ b/skater/tests/test_data.py
@@ -100,6 +100,14 @@ class TestData(unittest.TestCase):
                                                            "not loaded properly"
         assert data_set.index == self.index, "Index from DataFrame not loaded properly"
         assert_array_equal(data_set.X, self.X)
+        try:
+            feature_info = data_set.feature_info
+            for feature in self.feature_names:
+                assert feature in feature_info
+        except ValueError as e:
+            raise e
+        except KeyError as e:
+            assert False, "{:} not found in feature_info".format(feature)
 
 
     def test_generate_grid_1_variable(self):


### PR DESCRIPTION
#241 

Pandas DataFrames have not been properly tests, and calling "feature_info" for a DataManager initialized with a DataFrame raises ValueError. 

This pull-request includes an update to test_data.py, which raises a proper error to show this bug. Am working on a correction.